### PR TITLE
Finish Python 2 and 3 compat: metaclasses, builtins

### DIFF
--- a/examples/EM_demo.py
+++ b/examples/EM_demo.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from builtins import range
 import numpy as np
 np.seterr(invalid='raise')
 from matplotlib import pyplot as plt
@@ -37,7 +38,7 @@ BICs = []
 examplemodels = []
 for idx, num_components in enumerate(progprint_xrange(min_num_components,max_num_components+1)):
     theseBICs = []
-    for i in xrange(num_tries_each):
+    for i in range(num_tries_each):
         fitmodel = models.Mixture(
                 alpha_0=10000, # used for random initialization Gibbs sampling, big means use all components
                 components=[distributions.Gaussian(**obs_hypparams) for itr in range(num_components)])
@@ -45,11 +46,11 @@ for idx, num_components in enumerate(progprint_xrange(min_num_components,max_num
         fitmodel.add_data(data)
 
         # use Gibbs sampling for initialization
-        for itr in xrange(100):
+        for itr in range(100):
             fitmodel.resample_model()
 
         # use EM to fit a model
-        for itr in xrange(50):
+        for itr in range(50):
             fitmodel.EM_step()
 
         theseBICs.append(fitmodel.BIC())

--- a/examples/animation.py
+++ b/examples/animation.py
@@ -1,5 +1,6 @@
 from __future__ import division
 from __future__ import print_function
+from builtins import range
 import numpy as np
 import numpy.random as npr
 from matplotlib import pyplot as plt

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,5 +1,7 @@
 from __future__ import division
 from __future__ import print_function
+from builtins import zip
+from builtins import range
 import numpy as np
 np.seterr(invalid='raise')
 from matplotlib import pyplot as plt

--- a/examples/meanfield_steps.py
+++ b/examples/meanfield_steps.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from builtins import input
+from builtins import range
 import numpy as np
 from matplotlib import pyplot as plt
 plt.interactive(True)
@@ -23,7 +25,7 @@ plt.figure()
 plt.plot(data[:,0],data[:,1],'kx')
 plt.title('data')
 
-raw_input() # pause for effect
+input() # pause for effect
 
 ###############
 #  inference  #
@@ -39,7 +41,7 @@ plt.figure(2,figsize=(8,6))
 posteriormodel.plot()
 plt.figure(3,figsize=(8,6))
 while True:
-    if raw_input().lower() == 'break': # pause at each iteration
+    if input().lower() == 'break': # pause at each iteration
         break
 
     vlb = posteriormodel.meanfield_coordinate_descent_step()

--- a/pybasicbayes/distributions/binomial.py
+++ b/pybasicbayes/distributions/binomial.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from builtins import zip
 __all__ = ['Binomial']
 
 import numpy as np

--- a/pybasicbayes/distributions/gaussian.py
+++ b/pybasicbayes/distributions/gaussian.py
@@ -1,4 +1,8 @@
 from __future__ import division
+from builtins import map
+from builtins import zip
+from builtins import range
+from builtins import object
 __all__ = \
     ['Gaussian', 'GaussianFixedMean', 'GaussianFixedCov', 'GaussianFixed',
      'GaussianNonConj', 'DiagonalGaussian', 'DiagonalGaussianNonconjNIG',
@@ -224,7 +228,7 @@ class Gaussian(
             out[-2,-2] = out[-1,-1] = data.shape[0]
             return out
         else:
-            return sum(map(self._get_statistics,data),out)
+            return sum(list(map(self._get_statistics,data)),out)
 
     def _get_weighted_statistics(self,data,weights,D=None):
         D = getdatadimension(data) if D is None else D
@@ -235,7 +239,7 @@ class Gaussian(
             out[-2,-2] = out[-1,-1] = weights.sum()
             return out
         else:
-            return sum(map(self._get_weighted_statistics,data,weights),out)
+            return sum(list(map(self._get_weighted_statistics,data,weights)),out)
 
     def _get_empty_statistics(self, D):
         out = np.zeros((D+2,D+2))
@@ -648,7 +652,7 @@ class GaussianNonConj(_GaussianBase, GibbsSampling):
 
         # TODO this is kinda dumb because it collects statistics over and over
         # instead of updating them...
-        for itr in xrange(niter):
+        for itr in range(niter):
             # resample mu
             self._mu_distn.sigma = self._sigma_distn.sigma
             self._mu_distn.resample(data)
@@ -942,7 +946,7 @@ class DiagonalGaussianNonconjNIG(_GaussianBase,GibbsSampling):
             self.mu = np.sqrt(self.sigmas_0) * np.random.randn(self.mu_0.shape[0]) + self.mu_0
             self.sigmas = 1./np.random.gamma(self.alpha_0,scale=1./self.beta_0)
         else:
-            for itr in xrange(self.niter):
+            for itr in range(self.niter):
                 sigmas_n = 1./(1./self.sigmas_0 + n / self.sigmas)
                 mu_n = (self.mu_0 / self.sigmas_0 + y / self.sigmas) * sigmas_n
                 self.mu = np.sqrt(sigmas_n) * np.random.randn(mu_n.shape[0]) + mu_n
@@ -1368,7 +1372,7 @@ class ScalarGaussianNonconjNIG(_ScalarGaussianBase, MeanField, MeanFieldSVI):
     def meanfieldupdate(self,data,weights,niter=None):
         niter = niter if niter is not None else self.niter
         neff, y, ysq = self._get_weighted_statistics(data,weights)
-        for niter in xrange(niter):
+        for niter in range(niter):
             # update q(sigmasq)
             Emu, _ = self._E_mu
 

--- a/pybasicbayes/distributions/geometric.py
+++ b/pybasicbayes/distributions/geometric.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from builtins import zip
 __all__ = ['Geometric']
 
 import numpy as np

--- a/pybasicbayes/distributions/meta.py
+++ b/pybasicbayes/distributions/meta.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from builtins import zip
+from builtins import range
 __all__ = ['_FixedParamsMixin', 'ProductDistribution']
 
 import numpy as np
@@ -31,7 +33,7 @@ class ProductDistribution(
     def __init__(self, distns, slices=None):
         self._distns = distns
         self._slices = slices if slices is not None else \
-            [slice(i, i+1) for i in xrange(len(distns))]
+            [slice(i, i+1) for i in range(len(distns))]
 
     @property
     def params(self):

--- a/pybasicbayes/distributions/multinomial.py
+++ b/pybasicbayes/distributions/multinomial.py
@@ -1,4 +1,7 @@
 from __future__ import division
+from builtins import zip
+from builtins import map
+from builtins import range
 __all__ = ['Categorical', 'CategoricalAndConcentration', 'Multinomial',
            'MultinomialAndConcentration', 'GammaCompoundDirichlet', 'CRP']
 
@@ -380,7 +383,7 @@ class CRP(GibbsSampling):
             total_num_distinct = 0
         else:
             if isinstance(data[0],list):
-                sample_numbers = np.array(map(sum,data))
+                sample_numbers = np.array(list(map(sum,data)))
                 total_num_distinct = sum(map(len,data))
             else:
                 sample_numbers = np.array(sum(data))

--- a/pybasicbayes/distributions/negativebinomial.py
+++ b/pybasicbayes/distributions/negativebinomial.py
@@ -1,4 +1,7 @@
 from __future__ import division
+from builtins import zip
+from builtins import range
+from builtins import object
 __all__ = [
     'NegativeBinomial', 'NegativeBinomialFixedR', 'NegativeBinomialIntegerR2',
     'NegativeBinomialIntegerR', 'NegativeBinomialFixedRVariant',
@@ -490,7 +493,7 @@ class NegativeBinomialIntegerR(NegativeBinomialFixedR, GibbsSampling, MaxLikelih
 
     def rvs(self,size=None):
         out = np.random.geometric(1-self.p,size=size)-1
-        for i in xrange(self.r-1):
+        for i in range(self.r-1):
             out += np.random.geometric(1-self.p,size=size)-1
         return out
 

--- a/pybasicbayes/distributions/poisson.py
+++ b/pybasicbayes/distributions/poisson.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from builtins import zip
 __all__ = ['Poisson']
 import numpy as np
 import scipy.stats as stats

--- a/pybasicbayes/distributions/regression.py
+++ b/pybasicbayes/distributions/regression.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from builtins import zip
+from builtins import range
 __all__ = ['Regression', 'RegressionNonconj', 'ARDRegression']
 
 import numpy as np
@@ -228,7 +230,7 @@ class RegressionNonconj(Regression):
             self.sigma = sample_invwishart(self.S_0,self.nu_0)
         else:
             yyT, yxT, xxT, n = self._get_statistics(data)
-            for itr in xrange(niter):
+            for itr in range(niter):
                 self._resample_A(xxT, yxT, self.sigma)
                 self._resample_sigma(xxT, yxT, yyT, n, self.A)
 
@@ -273,7 +275,7 @@ class ARDRegression(Regression):
     def resample(self,data=[],stats=None):
         if len(data) > 0 or stats is not None:
             stats = self._get_statistics(data) if stats is None else stats
-            for itr in xrange(self.niter):
+            for itr in range(self.niter):
                 self.A, self.sigma = \
                     sample_mniw(*self._natural_to_standard(
                         self.natural_hypparam + stats))

--- a/pybasicbayes/distributions/uniform.py
+++ b/pybasicbayes/distributions/uniform.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from builtins import map
+from builtins import range
 __all__ = ['UniformOneSided', 'Uniform']
 
 import numpy as np
@@ -118,7 +120,7 @@ class Uniform(UniformOneSided):
             self.low = -sample_pareto(-self.x_m_low,self.alpha_low)
             self.high = sample_pareto(self.x_m_high,self.alpha_high)
         else:
-            for itr in xrange(niter):
+            for itr in range(niter):
                 # resample high, fixing low
                 self.x_m, self.alpha = self.x_m_high, self.alpha_high
                 super(Uniform,self).resample(data)
@@ -132,4 +134,4 @@ class Uniform(UniformOneSided):
         if isinstance(data,np.ndarray):
             return self.x_m_low - data
         else:
-            return map(self._flip_data,data)
+            return list(map(self._flip_data,data))

--- a/pybasicbayes/models.py
+++ b/pybasicbayes/models.py
@@ -1,7 +1,11 @@
 from __future__ import division
 from __future__ import absolute_import
+from builtins import zip
+from builtins import range
+from builtins import object
 import numpy as np
 from functools import reduce
+from future.utils import with_metaclass
 na = np.newaxis
 import scipy.special as special
 import abc, copy
@@ -553,7 +557,7 @@ class Mixture(ModelGibbsSampling, ModelMeanField, ModelEM, ModelParallelTemperin
         if legend and color is None:
             plt.legend(
                 [plt.Rectangle((0,0),1,1,fc=c)
-                    for i,c in label_colors.iteritems() if i in used_labels],
+                    for i,c in label_colors.items() if i in used_labels],
                 [i for i in label_colors if i in used_labels],
                 loc='best', ncol=2)
 
@@ -569,7 +573,7 @@ class Mixture(ModelGibbsSampling, ModelMeanField, ModelEM, ModelParallelTemperin
 
         return  {
                     'points':[{'x':x,'y':y,'label':int(label)} for x,y,label in zip(data[:,0],data[:,1],z)],
-                    'ellipses':[dict(c.to_json_dict().items() + [('label',i)])
+                    'ellipses':[dict(list(c.to_json_dict().items()) + [('label',i)])
                         for i,c in enumerate(self.components) if i in z]
                 }
 
@@ -716,8 +720,7 @@ class MixtureDistribution(Mixture, GibbsSampling, MeanField, MeanFieldSVI, Distr
             self.labels_list.pop()
 
 
-class CollapsedMixture(ModelGibbsSampling):
-    __metaclass__ = abc.ABCMeta
+class CollapsedMixture(with_metaclass(abc.ABCMeta, ModelGibbsSampling)):
     def _get_counts(self,k):
         return sum(l._get_counts(k) for l in self.labels_list)
 

--- a/pybasicbayes/testing/mixins.py
+++ b/pybasicbayes/testing/mixins.py
@@ -1,4 +1,7 @@
 from __future__ import division
+from builtins import zip
+from builtins import range
+from builtins import object
 import numpy as np
 import abc, os
 
@@ -6,10 +9,9 @@ from nose.plugins.attrib import attr
 
 import pybasicbayes
 from pybasicbayes.util import testing
+from future.utils import with_metaclass
 
-class DistributionTester(object):
-    __metaclass__ = abc.ABCMeta
-
+class DistributionTester(with_metaclass(abc.ABCMeta, object)):
     @abc.abstractproperty
     def distribution_class(self):
         pass
@@ -75,9 +77,7 @@ class BasicTester(DistributionTester):
 
             self._check_stats(s1,s2)
 
-class BigDataGibbsTester(DistributionTester):
-    __metaclass__ = abc.ABCMeta
-
+class BigDataGibbsTester(with_metaclass(abc.ABCMeta, DistributionTester)):
     @abc.abstractmethod
     def params_close(self,distn1,distn2):
         pass
@@ -110,9 +110,7 @@ class BigDataGibbsTester(DistributionTester):
 
         assert self.params_close(d1,d2)
 
-class MaxLikelihoodTester(DistributionTester):
-    __metaclass__ = abc.ABCMeta
-
+class MaxLikelihoodTester(with_metaclass(abc.ABCMeta, DistributionTester)):
     @abc.abstractmethod
     def params_close(self,distn1,distn2):
         pass
@@ -145,9 +143,7 @@ class MaxLikelihoodTester(DistributionTester):
 
         assert self.params_close(d1,d2)
 
-class GewekeGibbsTester(DistributionTester):
-    __metaclass__ = abc.ABCMeta
-
+class GewekeGibbsTester(with_metaclass(abc.ABCMeta, DistributionTester)):
     @abc.abstractmethod
     def geweke_statistics(self,distn,data):
         pass
@@ -213,10 +209,10 @@ class GewekeGibbsTester(DistributionTester):
         sample_dim = np.atleast_1d(self.geweke_statistics(d,d.rvs(size=10))).shape[0]
 
         num_statistic_fails = 0
-        for trial in xrange(ntrials):
+        for trial in range(ntrials):
             # collect forward-generated statistics
             forward_statistics = np.squeeze(np.empty((nsamples,sample_dim)))
-            for i in xrange(nsamples):
+            for i in range(nsamples):
                 d = self.distribution_class(**hypparam_dict)
                 data = d.rvs(size=data_size)
                 forward_statistics[i] = self.geweke_statistics(d,data)
@@ -225,7 +221,7 @@ class GewekeGibbsTester(DistributionTester):
             gibbs_statistics = np.squeeze(np.empty((nsamples,sample_dim)))
             d = self.distribution_class(**hypparam_dict)
             data = d.rvs(size=data_size)
-            for i in xrange(nsamples):
+            for i in range(nsamples):
                 d.resample(data,**self.geweke_resample_kwargs)
                 data = d.rvs(size=data_size)
                 gibbs_statistics[i] = self.geweke_statistics(d,data)

--- a/pybasicbayes/util/cyutil.py
+++ b/pybasicbayes/util/cyutil.py
@@ -1,3 +1,5 @@
+from builtins import map
+from builtins import str
 import Cython.Build
 from Cython.Build.Dependencies import *
 
@@ -14,7 +16,7 @@ def create_extension_list(patterns, exclude=[], ctx=None, aliases=None, quiet=Fa
     if not isinstance(exclude, list):
         exclude = [exclude]
     for pattern in exclude:
-        to_exclude.update(map(os.path.abspath, extended_iglob(pattern)))
+        to_exclude.update(list(map(os.path.abspath, extended_iglob(pattern))))
 
     module_list = []
     for pattern in patterns:
@@ -60,7 +62,7 @@ def create_extension_list(patterns, exclude=[], ctx=None, aliases=None, quiet=Fa
                         continue
                     raise
                 if base is not None:
-                    for key, value in base.values.items():
+                    for key, value in list(base.values.items()):
                         if key not in kwds:
                             kwds[key] = value
 

--- a/pybasicbayes/util/general.py
+++ b/pybasicbayes/util/general.py
@@ -1,4 +1,9 @@
 from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import next
+from builtins import zip
+from builtins import range
 import sys
 import numpy as np
 from numpy.lib.stride_tricks import as_strided as ast
@@ -8,15 +13,7 @@ import copy, collections, os, shutil, hashlib
 from contextlib import closing
 from itertools import chain, count
 from functools import reduce
-
-PY2 = sys.version_info[0] == 2
-
-if PY2:
-    from urllib2 import urlopen
-    from itertools import izip as zip
-    from itertools import ifilter as filter
-else:
-    from urllib.request import urlopen
+from urllib.request import urlopen  # py2.7 covered by standard_library.install_aliases()
 
 
 def blockarray(*args,**kwargs):
@@ -82,7 +79,7 @@ def nice_indices(arr):
     # surprisingly, this is slower for very small (and very large) inputs:
     # u,f,i = np.unique(arr,return_index=True,return_inverse=True)
     # arr[:] = np.arange(u.shape[0])[np.argsort(f)][i]
-    ids = collections.defaultdict(count().next)
+    ids = collections.defaultdict(count().__next__)
     for idx,x in enumerate(arr):
         arr[idx] = ids[x]
     return arr
@@ -149,7 +146,7 @@ def _sieve(stream):
     # just for fun; doesn't work over a few hundred
     val = next(stream)
     yield val
-    for x in filter(lambda x: x%val != 0, _sieve(stream)):
+    for x in [x for x in _sieve(stream) if x % val != 0]:
         yield x
 
 def primes():
@@ -176,7 +173,7 @@ def top_eigenvector(A,niter=1000,force_iteration=False):
     else:
         x1 = np.repeat(1./n,n)
         x2 = x1.copy()
-        for itr in xrange(niter):
+        for itr in range(niter):
             np.dot(A.T,x1,out=x2)
             x2 /= x2.sum()
             x1,x2 = x2,x1
@@ -232,7 +229,7 @@ def hold_out(datalist,frac):
 def sgd_passes(tau,kappa,datalist,minibatchsize=1,npasses=1):
     N = len(datalist)
 
-    for superitr in xrange(npasses):
+    for superitr in range(npasses):
         if minibatchsize == 1:
             perm = np.random.permutation(N)
             for idx, rho_t in zip(perm,sgd_steps(tau,kappa)):
@@ -261,7 +258,7 @@ def minibatchsize(lst):
 
 def random_subset(lst,sz):
     perm = np.random.permutation(len(lst))
-    return [lst[perm[idx]] for idx in xrange(sz)]
+    return [lst[perm[idx]] for idx in range(sz)]
 
 def get_file(remote_url,local_path):
     if not os.path.isfile(local_path):

--- a/pybasicbayes/util/plot.py
+++ b/pybasicbayes/util/plot.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from builtins import range
 import numpy as np
 from matplotlib import pyplot as plt
 

--- a/pybasicbayes/util/profiling.py
+++ b/pybasicbayes/util/profiling.py
@@ -1,7 +1,9 @@
 from __future__ import division
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
 import numpy as np
-import sys, StringIO, inspect, os, functools, time, collections
+import sys, io, inspect, os, functools, time, collections
 
 ### use @timed for really basic timing
 
@@ -22,7 +24,7 @@ def show_timings(stream=None):
     if len(_timings) > 0:
         results = [(inspect.getsourcefile(f),f.__name__,
             len(vals),np.sum(vals),np.mean(vals),np.std(vals))
-            for f, vals in _timings.iteritems()]
+            for f, vals in _timings.items()]
         filename_lens = max(len(filename) for filename, _, _, _, _, _ in results)
         name_lens = max(len(name) for _, name, _, _, _, _ in results)
 

--- a/pybasicbayes/util/stats.py
+++ b/pybasicbayes/util/stats.py
@@ -1,5 +1,6 @@
 from __future__ import division
 from __future__ import absolute_import
+from builtins import range
 import numpy as np
 from numpy.random import random
 na = np.newaxis
@@ -245,7 +246,7 @@ def sample_crp_tablecounts(concentration,customers,colweights):
 
     for (i,j), n in np.ndenumerate(customers):
         w = colweights[j]
-        for k in xrange(n):
+        for k in range(n):
             m[i,j] += randseq[starts[i,j]+k] \
                     < (concentration * w) / (k + concentration * w)
 

--- a/pybasicbayes/util/testing.py
+++ b/pybasicbayes/util/testing.py
@@ -1,5 +1,6 @@
 from __future__ import division
 from __future__ import absolute_import
+from builtins import zip
 import numpy as np
 from numpy import newaxis as na
 

--- a/pybasicbayes/util/text.py
+++ b/pybasicbayes/util/text.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import range
 import numpy as np
 import sys, time
 
@@ -21,7 +22,7 @@ def sec2str(seconds):
         return '%0.2f' % seconds
 
 def progprint_xrange(*args,**kwargs):
-    xr = xrange(*args)
+    xr = range(*args)
     return progprint(xr,total=len(xr),**kwargs)
 
 def progprint(iterator,total=None,perline=25,show_times=True):

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(name='pybasicbayes',
           "scipy",
           "matplotlib",
           "nose",
+          "future",
       ],
       classifiers=[
           'Intended Audience :: Science/Research',

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from builtins import range
+from builtins import object
 import numpy as np
 
 from nose.plugins.attrib import attr


### PR DESCRIPTION
Ran futurize stage2, see http://python-future.org/futurize_cheatsheet.html.

python-future appears to be the current choice (e.g., over six) for
helping to maintain a codebase that's Python 2 and Python 3 compatible.
eight is another option but it appears targeted at people starting from
a Python 3 codebase.

Note that you do need to use the Python 3 syntax for range,
filter, and zip (e.g., range now calls xrange under Python 2.)